### PR TITLE
Remove forwarded port

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,13 +11,6 @@
         "github.copilot",
         "vsls-contrib.codetour",
         "ms-python.python"
-      ]},
-    "portsAttributes": {
-      "3000": {
-        "label": "README",
-        "onAutoForward": "openPreview"
-      }
-    }
-  },
-  "forwardPorts": [3000]
+      ]}
+  }
 }


### PR DESCRIPTION
We're not actually forwarding anything on the port so remove it so users don't try to load it.